### PR TITLE
Enable sourcemaps

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,9 @@ module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     // Add build options here
     sourcemaps: ['js'],
+    // Fix issue with minification + sourcemap in FileSave.js
+    // See https://github.com/ember-cli/ember-cli-uglify/issues/4
+    minifyJS: { enabled: false }
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,8 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
-    // Add options here
+    // Add build options here
+    sourcemaps: ['js'],
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
Enable Javascript sourcemaps in the production builds.

This allow for easier debugging of the production version in the browser. Also, it may help Firefox people to fix issues in the Web Inspector with large sourcemaps :)

@Tristramg please review